### PR TITLE
Set [] as default value for --no-relocate-shebang-list

### DIFF
--- a/venvjail.py
+++ b/venvjail.py
@@ -557,6 +557,7 @@ if __name__ == '__main__':
                            default='/opt/stack/venv',
                            help='Relocated virtual environment directory')
     subparser.add_argument('--no-relocate-shebang-list', metavar='PATH',
+                           default=[],
                            nargs='+',
                            help='Do not change the shebang in these files. '
                                'Wildcards supported (fnmatch/bash style). '


### PR DESCRIPTION
With no default (which means None), we get this when
--no-relocate-shebang-list isn't used:
```
  Traceback (most recent call last):
    File "/usr/bin/venvjail", line 650, in <module>
      args.func(args)
    File "/usr/bin/venvjail", line 414, in create
      _fix_virtualenv(args.dest_dir, args.relocate, args.no_relocate_shebang_list)
    File "/usr/bin/venvjail", line 119, in _fix_virtualenv
      _fix_relocation(dest_dir, virtual_env, no_relocate_shebang)
    File "/usr/bin/venvjail", line 219, in _fix_relocation
      for path in no_relocate_shebang):
  TypeError: 'NoneType' object is not iterable
```